### PR TITLE
Make LibVirt Template work with older versions of QEMU

### DIFF
--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>2097152</currentMemory>
   <vcpu placement='static'>4</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-q35-3.0'>hvm</type>
+    <type arch='x86_64' machine='q35'>hvm</type>
     <loader readonly='yes' type='pflash'>VMDIR/firmware/OVMF_CODE.fd</loader>
     <nvram>VMDIR/firmware/OVMF_VARS-1024x768.fd</nvram>
     <boot dev='hd'/>


### PR DESCRIPTION
This was needed to get the KVM to boot with "QEMU emulator version 2.11.1(Debian 1:2.11+dfsg-1ubuntu7.14)" that comes with Ubuntu 18.04 / KDE Neon