### PR TITLE
Setup simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,19 @@ Create an empty hard disk using `qemu-img`, changing the name and size to prefer
 qemu-img create -f qcow2 MyDisk.qcow2 64G
 ```
 
-> Note: If you're running on a headless system (such as on Cloud providers), you will need to add `-nographic` and `-vnc :0 -k en-us` (for VNC support) to the end of `basic.sh`.
-
 Then run `basic.sh` to start the machine and install macOS, setting the
 `SYSTEM_DISK` environment variable to the path to your freshly created
 system disk image:
 
 ```
 SYSTEM_DISK=MyDisk.qcow2 ./basic.sh
+```
+
+If you're running on a headless system (such as on Cloud providers), set
+the `HEADLESS` environment variable to 1:
+
+```
+SYSTEM_DISK=MyDisk.qcow2 HEADLESS=1 ./basic.sh
 ```
 
 Remember to partition in Disk Utility first!

--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ Create an empty hard disk using `qemu-img`, changing the name and size to prefer
 qemu-img create -f qcow2 MyDisk.qcow2 64G
 ```
 
-and add it to the end of `basic.sh`:
-```
-    -drive id=SystemDisk,if=none,file=MyDisk.qcow2 \
-    -device ide-hd,bus=sata.4,drive=SystemDisk \
-```
-> Note: If you're running on a headless system (such as on Cloud providers), you will need `-nographic` and `-vnc :0 -k en-us` for VNC support.
+> Note: If you're running on a headless system (such as on Cloud providers), you will need to add `-nographic` and `-vnc :0 -k en-us` (for VNC support) to the end of `basic.sh`.
 
-Then run `basic.sh` to start the machine and install macOS. Remember to partition in Disk Utility first!
+Then run `basic.sh` to start the machine and install macOS, setting the
+`SYSTEM_DISK` environment variable to the path to your freshly created
+system disk image:
+
+```
+SYSTEM_DISK=MyDisk.qcow2 ./basic.sh
+```
+
+Remember to partition in Disk Utility first!
 
 ## Step 2a (Virtual Machine Manager)
 If instead of QEMU, you'd like to import the setup into Virt-Manager for further configuration, just run `make.sh --add`.

--- a/basic.sh
+++ b/basic.sh
@@ -16,6 +16,12 @@ OVMF=$VMDIR/firmware
     exit 1
 }
 
+MOREARGS=()
+
+[[ "$HEADLESS" = "1" ]] && {
+    MOREARGS+=(-nographic -vnc :0 -k en-us)
+}
+
 qemu-system-x86_64 \
     -enable-kvm \
     -m 2G \
@@ -37,4 +43,5 @@ qemu-system-x86_64 \
     -drive id=InstallMedia,if=none,file=BaseSystem.img \
     -device ide-hd,bus=sata.3,drive=InstallMedia \
     -drive id=SystemDisk,if=none,file="${SYSTEM_DISK}" \
-    -device ide-hd,bus=sata.4,drive=SystemDisk
+    -device ide-hd,bus=sata.4,drive=SystemDisk \
+    ${MOREARGS[@]}

--- a/basic.sh
+++ b/basic.sh
@@ -6,6 +6,16 @@ OVMF=$VMDIR/firmware
 #export QEMU_AUDIO_DRV=pa
 #QEMU_AUDIO_DRV=pa
 
+[[ -z "$SYSTEM_DISK" ]] && {
+    echo "Please set the SYSTEM_DISK environment variable"
+    exit 1
+}
+
+[[ -r "$SYSTEM_DISK" ]] || {
+    echo "Can't read system disk image: $SYSTEM_DISK"
+    exit 1
+}
+
 qemu-system-x86_64 \
     -enable-kvm \
     -m 2G \
@@ -26,3 +36,5 @@ qemu-system-x86_64 \
     -device ide-hd,bus=sata.2,drive=ESP \
     -drive id=InstallMedia,if=none,file=BaseSystem.img \
     -device ide-hd,bus=sata.3,drive=InstallMedia \
+    -drive id=SystemDisk,if=none,file="${SYSTEM_DISK}" \
+    -device ide-hd,bus=sata.4,drive=SystemDisk


### PR DESCRIPTION
This teaches `basic.sh` about a few environment variables in order to reduce the amount of hand-editing that needs to be done to get a system up and running.  Namely:

### `SYSTEM_DISK`
Currently users have to modify the basic.sh script by hand to add the path
to the system disk image they created.  Rather than having them modify the
script, just grab it from the environment.

### `HEADLESS`
Currently if a user wants to run in headless mode they have to edit the
basic.sh script by hand.  Rather than making them edit the script by hand,
add support for a HEADLESS environment variable which can be set to 1 to
add necessary command line arguments to qemu.

---

Examples:

```
SYSTEM_DISK=MyDisk.qcow2 ./basic.sh
```

```
SYSTEM_DISK=MyDisk.qcow2 HEADLESS=1 ./basic.sh
```