### PR TITLE
Add note about automatic internet to networking.md

### DIFF
--- a/docs/guide-networking.md
+++ b/docs/guide-networking.md
@@ -1,5 +1,8 @@
 Guide to Bridged Networking
 ===========================
+
+*Note*: you don't need to set up bridged networking just to get internet access. With `basic.sh` you should be able to access the internet from MacOS automatically. *However*, the ICMP protocol (used for `ping`) is not supported with the default networking solution. 
+
 To set up bridged networking for the macOS VM, use one of the following methods:
 
 


### PR DESCRIPTION
So I wasted 1,5 hours trying to make bridged networking work just
to get internet access in MacOS. I thought I didn't have internet in
the VM because I tried to `ping 1.1.1.1`. Hopefully this note can
help future users not to waste their time, too.