### PR TITLE
fixes from shellcheck

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -14,8 +14,8 @@ qemu-system-x86_64 \
     -cpu Penryn,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc \
     -device isa-applesmc,osk="$OSK" \
     -smbios type=2 \
-    -drive if=pflash,format=raw,readonly,file=$OVMF/OVMF_CODE.fd \
-    -drive if=pflash,format=raw,file=$OVMF/OVMF_VARS-1024x768.fd \
+    -drive if=pflash,format=raw,readonly,file="$OVMF/OVMF_CODE.fd" \
+    -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga qxl \
     -device ich9-intel-hda -device hda-output \
     -usb -device usb-kbd -device usb-mouse \

--- a/headless.sh
+++ b/headless.sh
@@ -36,8 +36,8 @@ qemu-system-x86_64 \
     -cpu Penryn,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc \
     -device isa-applesmc,osk="$OSK" \
     -smbios type=2 \
-    -drive if=pflash,format=raw,readonly,file=$OVMF/OVMF_CODE.fd \
-    -drive if=pflash,format=raw,file=$OVMF/OVMF_VARS-1024x768.fd \
+    -drive if=pflash,format=raw,readonly,file="$OVMF/OVMF_CODE.fd" \
+    -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga qxl \
     -usb -device usb-kbd -device usb-tablet \
     -netdev user,id=net0 \
@@ -49,4 +49,4 @@ qemu-system-x86_64 \
     -device ide-hd,bus=sata.3,drive=InstallMedia \
     -drive id=SystemDisk,if=none,file="${SYSTEM_DISK}" \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
-    ${MOREARGS[@]}
+    "${MOREARGS[@]}"

--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -16,24 +16,24 @@ print_usage() {
 }
 
 error() {
-    local error_message="$@"
+    local error_message="$*"
     echo "${error_message}" 1>&2;
 }
 
 argument="$1"
 case $argument in
-    -s|--high-sierra)
-        $TOOLS/FetchMacOS/fetch.sh -p 091-95155 -c PublicRelease13 || exit 1;
-        ;;
-    -m|--mojave)
-        $TOOLS/FetchMacOS/fetch.sh -l -c PublicRelease14 || exit 1;
-        ;;
-    -c|--catalina|*)
-        $TOOLS/FetchMacOS/fetch.sh -l -c DeveloperSeed || exit 1;
-        ;;
     -h|--help)
         print_usage
         ;;
+    -s|--high-sierra)
+        "$TOOLS/FetchMacOS/fetch.sh" -p 091-95155 -c PublicRelease13 || exit 1;
+        ;;
+    -m|--mojave)
+        "$TOOLS/FetchMacOS/fetch.sh" -l -c PublicRelease14 || exit 1;
+        ;;
+    -c|--catalina|*)
+        "$TOOLS/FetchMacOS/fetch.sh" -l -c DeveloperSeed || exit 1;
+        ;;
 esac
 
-$TOOLS/dmg2img $TOOLS/FetchMacOS/BaseSystem/BaseSystem.dmg $PWD/BaseSystem.img
+"$TOOLS/dmg2img" "$TOOLS/FetchMacOS/BaseSystem/BaseSystem.dmg" "$PWD/BaseSystem.img"

--- a/make.sh
+++ b/make.sh
@@ -4,7 +4,7 @@
 # by Foxlet <foxlet@furcode.co>
 
 VMDIR=$PWD
-MACHINE=$(qemu-system-x86_64 --machine help | grep q35 | cut -d" " -f1 | egrep -oe ".*-[0-9.]+" | sort -rV | head -1)
+MACHINE="$(qemu-system-x86_64 --machine help | grep q35 | cut -d" " -f1 | grep -Eoe ".*-[0-9.]+" | sort -rV | head -1)"
 OUT="template.xml"
 
 print_usage() {
@@ -16,7 +16,7 @@ print_usage() {
 }
 
 error() {
-    local error_message="$@"
+    local error_message="$*"
     echo "${error_message}" 1>&2;
 }
 

--- a/tools/FetchMacOS/fetch.sh
+++ b/tools/FetchMacOS/fetch.sh
@@ -5,7 +5,7 @@
 
 set +x;
 SCRIPTDIR="$(dirname "$0")";
-cd $SCRIPTDIR
+cd "$SCRIPTDIR"
 
 initpip() {
     if [ -x "$(command -v easy_install)" ]; then
@@ -43,6 +43,6 @@ getpython(){
 
 getpip
 getpython
-$PYTHONBIN fetch-macos.py $*
+$PYTHONBIN fetch-macos.py "$@"
 
 exit;

--- a/virtio.sh
+++ b/virtio.sh
@@ -15,8 +15,8 @@ qemu-system-x86_64 \
     -cpu Penryn,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc \
     -device isa-applesmc,osk="$OSK" \
     -smbios type=2 \
-    -drive if=pflash,format=raw,readonly,file=$OVMF/OVMF_CODE.fd \
-    -drive if=pflash,format=raw,file=$OVMF/OVMF_VARS-1024x768.fd \
+    -drive if=pflash,format=raw,readonly,file="$OVMF/OVMF_CODE.fd" \
+    -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga std \
     -device ich9-intel-hda -device hda-output \
     -usb -device usb-kbd -device usb-mouse \


### PR DESCRIPTION
Fixes for paths with spaces (use double quotes).
Fixes `--help` (fall-through case must be last).
Other general tweaks found via `shellcheck`.