### PR TITLE
Change usb-mouse to usb-tablet

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -18,7 +18,7 @@ qemu-system-x86_64 \
     -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga qxl \
     -device ich9-intel-hda -device hda-output \
-    -usb -device usb-kbd -device usb-mouse \
+    -usb -device usb-kbd -device usb-tablet \
     -netdev user,id=net0 \
     -device e1000-82545em,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
     -device ich9-ahci,id=sata \


### PR DESCRIPTION
usb-tablet allows you to use the VM without constantly having to grab and ungrab input. Almost everything works without the input grabbed, except when host OS keystrokes/shortcuts override guest shortcuts, like super-H hiding the qemu menu in gnome/budgie, rather than hiding the active program in MacOS.