### PR TITLE
fix jumpstart to download mojave version when flag -j is set

### DIFF
--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -29,7 +29,7 @@ case $argument in
         "$TOOLS/FetchMacOS/fetch.sh" -p 091-95155 -c PublicRelease13 || exit 1;
         ;;
     -m|--mojave)
-        "$TOOLS/FetchMacOS/fetch.sh" -l -c PublicRelease14 || exit 1;
+        "$TOOLS/FetchMacOS/fetch.sh"  -p 041-47723 -c PublicRelease14 || exit 1;
         ;;
     -c|--catalina|*)
         "$TOOLS/FetchMacOS/fetch.sh" -l -c PublicRelease || exit 1;


### PR DESCRIPTION
issue #103 not download mojave when flag -j is specified. 

this fix will download mojave version 10.14.4