### PR TITLE
Better usability for jumpstart.sh

### DIFF
--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -20,20 +20,35 @@ error() {
     echo "${error_message}" 1>&2;
 }
 
-argument="$1"
-case $argument in
-    -h|--help)
-        print_usage
-        ;;
-    -s|--high-sierra)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.13 || exit 1;
-        ;;
-    -m|--mojave)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.14 || exit 1;
-        ;;
-    -c|--catalina|*)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.15 || exit 1;
-        ;;
-esac
 
+version[0]="10.15"
+version[1]="Catalina"
+argument="$1"
+if [ ! -z "$argument" ]
+then
+    case $argument in
+        -h|--help)
+            print_usage
+            ;;
+        -s|--high-sierra)
+            version[0]="10.13"
+            version[1]="High Sierra"
+            ;;
+        -m|--mojave)
+            version[0]="10.14"
+            version[1]="Mojave"
+            ;;
+        -c|--catalina)
+            version[0]="10.15"
+            version[1]="Catalina"
+            ;;
+        *) echo "Invalid argument, $argument."
+           print_usage
+           exit 1
+           ;;
+    esac
+fi
+
+echo "Fetching Mac OS ${version[1]}"
+"$TOOLS/FetchMacOS/fetch.sh" -v "${version[0]}" || exit 1;
 "$TOOLS/dmg2img" "$TOOLS/FetchMacOS/BaseSystem/BaseSystem.dmg" "$PWD/BaseSystem.img"


### PR DESCRIPTION
Still downloads Catalina by default, but gives an error if you misspell one of the switches, and prints usage.

Also echos which version it downloads.