### PR TITLE
Run as unprivileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ and add it to the end of `basic.sh`:
 
 Then run `basic.sh` to start the machine and install macOS. Remember to partition in Disk Utility first!
 
-## Step 2a (Virtual Machine Manager)
-1. If instead of QEMU, you'd like to import the setup into Virt-Manager for further configuration, just run `sudo ./make.sh --add`.
+## Step 2a (Virtual Machine Manager and Gnome Boxes)
+1. If instead of QEMU, you'd like to import the setup into Virt-Manager or Gnome Boxes for further configuration, just run `./make.sh --add`.
 2. After running the above command, add `MyDisk.qcow2` as storage in the properties of the newly added entry for VM.
 
 ## Step 2b (Headless Systems)

--- a/make.sh
+++ b/make.sh
@@ -11,7 +11,7 @@ print_usage() {
     echo
     echo "Usage: $0"
     echo
-    echo " -a, --add   Add XML to virsh (uses sudo)."
+    echo " -a, --add   Add XML to virsh."
     echo
 }
 
@@ -21,7 +21,8 @@ error() {
 }
 
 generate(){
-    sed -e "s|VMDIR|$VMDIR|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
+    UUID=$( cat /proc/sys/kernel/random/uuid )
+    sed -e "s|VMDIR|$VMDIR|g" -e "s|UUID|$UUID|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
     echo "$OUT has been generated in $VMDIR"
 }
 
@@ -30,7 +31,7 @@ generate
 argument="$1"
 case $argument in
     -a|--add)
-        sudo virsh define $OUT
+        virsh -c qemu:///session define $OUT
         ;;
     -h|--help)
         print_usage

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -1,6 +1,6 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>macOS-Simple-KVM</name>
-  <uuid>d06d502a-904a-4b34-847d-debf1a3d76c7</uuid>
+  <uuid>UUID</uuid>
   <memory unit='KiB'>2097152</memory>
   <currentMemory unit='KiB'>2097152</currentMemory>
   <vcpu placement='static'>4</vcpu>
@@ -110,4 +110,3 @@
     <qemu:arg value='type=2'/>
   </qemu:commandline>
 </domain>
-


### PR DESCRIPTION
Hi, first of all thanks for this guide, I could finally dump Virtualbox for good ;-)

Now, after some research I think it is not mandatory nor *advisable* (unless really needed) to run a virtual machine on the hypervisor as root. Is there any reason why the guide runs everything as `sudo`?
In any case, this PR proposes to update the scripts in order to install everything as unprivileged user.

An additional positive side-effect is that the VM will now appear also in Gnome Boxes and fixes #149 

I also slightly improved the script in order to generate random UUIDs

What do you think?

Thanks for reviewing this PR