### PR TITLE
Support usermode qemu session and make simpler add macOS to GNOME Boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ BaseSystem.img
 BaseSystem.dmg
 BaseSystem.chunklist
 template.xml
+version

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ BaseSystem.dmg
 BaseSystem.chunklist
 template.xml
 version
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,360 @@
-.DS_Store
-BaseSystem.img
-BaseSystem.dmg
+# Ignore all user generated images
+*.img
+*.dmg
+*.qcow2
 BaseSystem.chunklist
+
+# Do not ignore ESP.qcow2
+!ESP.qcow2
+
+# Ignore user generated template
 template.xml
+
+# Ingore system version fire
 version
+
+# Ignore future use data folder
 data/
+
+
+# Created by https://www.gitignore.io/api/vim,code,linux,macos,emacs,windows,eclipse,sublimetext,intellij+all
+# Edit at https://www.gitignore.io/?templates=vim,code,linux,macos,emacs,windows,eclipse,sublimetext,intellij+all
+
+### Code ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+### Eclipse Patch ###
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/vim,code,linux,macos,emacs,windows,eclipse,sublimetext,intellij+all

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 BaseSystem.img
 BaseSystem.dmg
 BaseSystem.chunklist
+template.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # macOS-Simple-KVM
+
 Documentation to set up a simple macOS VM in QEMU, accelerated by KVM.
 
 By [@FoxletFox](https://twitter.com/foxletfox), and the help of many others. Find this useful? You can donate [on Coinbase](https://commerce.coinbase.com/checkout/96dc5777-0abf-437d-a9b5-a78ae2c4c227) or [Paypal!](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=QFXXKKAB2B9MA&item_name=macOS-Simple-KVM).
@@ -6,9 +7,10 @@ By [@FoxletFox](https://twitter.com/foxletfox), and the help of many others. Fin
 New to macOS and KVM? Check [the FAQs.](docs/FAQs.md)
 
 ## Getting Started
+
 You'll need a Linux system with `qemu` (3.1 or later), `python3`, `pip` and the KVM modules enabled. A Mac is **not** required. Some examples for different distributions:
 
-```
+```bash
 sudo apt-get install qemu-system qemu-utils python3 python3-pip  # for Ubuntu, Debian, Mint, and PopOS.
 sudo pacman -S qemu python python-pip            # for Arch.
 sudo xbps-install -Su qemu python3 python3-pip   # for Void Linux.
@@ -17,39 +19,50 @@ sudo dnf install qemu qemu-img python3 python3-pip # for Fedora
 ```
 
 ## Step 1
+
 Run `jumpstart.sh` to download installation media for macOS (internet required). The default installation uses Catalina, but you can choose which version to get by adding either `--high-sierra`, `--mojave`, or `--catalina`. For example:
-```
+
+```bash
 ./jumpstart.sh --mojave
 ```
+
 > Note: You can skip this if you already have `BaseSystem.img` downloaded. If you have `BaseSystem.dmg`, you will need to convert it with the `dmg2img` tool.
 
-## Step 2
+## Step 2a
+
 Create an empty hard disk using `qemu-img`, changing the name and size to preference:
-```
+
+```bash
 qemu-img create -f qcow2 MyDisk.qcow2 64G
 ```
 
 and add it to the end of `basic.sh`:
-```
+
+```bash
     -drive id=SystemDisk,if=none,file=MyDisk.qcow2 \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
 ```
-> Note: If you're running on a headless system (such as on Cloud providers), you will need `-nographic` and `-vnc :0 -k en-us` for VNC support.
+
+> **Note**: If you're running on a headless system (such as on Cloud providers), you will need `-nographic` and `-vnc :0 -k en-us` for VNC support.
 
 Then run `basic.sh` to start the machine and install macOS. Remember to partition in Disk Utility first!
 
-## Step 2a (Virtual Machine Manager)
-1. If instead of QEMU, you'd like to import the setup into Virt-Manager for further configuration, just run `sudo ./make.sh --add`.
-2. After running the above command, add `MyDisk.qcow2` as storage in the properties of the newly added entry for VM.
+## Step 2b (GNOME Boxes and Virtual Machine Manager)
 
-## Step 2b (Headless Systems)
+If instead of QEMU, you'd like to import the setup into GNOME Boxes or Virt-Manager for convenience or for further configuration, just run `./make.sh --install` or the shorter `./make.sh -i`.
+
+No root is needed because images will be installed in your home, with any other your Boxes virtual machine.
+
+## Step 2c (Headless Systems)
+
 If you're using a cloud-based/headless system, you can use `headless.sh` to set up a quick VNC instance. Settings are defined through variables as seen in the following example. VNC will start on port `5900` by default.
-```
+
+```bash
 HEADLESS=1 MEM=1G CPUS=2 SYSTEM_DISK=MyDisk.qcow2 ./headless.sh
 ```
 
 ## Step 3
 
-You're done!
+**You're done!**
 
 To fine-tune the system and improve performance, look in the `docs` folder for more information on [adding memory](docs/guide-performance.md), setting up [bridged networking](docs/guide-networking.md), adding [passthrough hardware (for GPUs)](docs/guide-passthrough.md), tweaking [screen resolution](docs/guide-screen-resolution.md), and enabling sound features.

--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -12,6 +12,7 @@ print_usage() {
     echo " -s, --high-sierra   Fetch High Sierra media."
     echo " -m, --mojave        Fetch Mojave media."
     echo " -c, --catalina      Fetch Catalina media."
+    echo " -b, --big-sur       Fetch Big Sur media."
     echo
 }
 
@@ -26,13 +27,16 @@ case $argument in
         print_usage
         ;;
     -s|--high-sierra)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.13 || exit 1;
+        "$TOOLS/FetchMacOS/fetch.sh" -v 10.13 -k BaseSystem || exit 1;
         ;;
     -m|--mojave)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.14 || exit 1;
+        "$TOOLS/FetchMacOS/fetch.sh" -v 10.14 -k BaseSystem || exit 1;
+        ;;
+    -b|--big-sur)
+        "$TOOLS/FetchMacOS/fetch.sh" -v 10.16 -c DeveloperSeed -p 001-18401-003 || exit 1;
         ;;
     -c|--catalina|*)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.15 || exit 1;
+        "$TOOLS/FetchMacOS/fetch.sh" -v 10.15 -k BaseSystem || exit 1;
         ;;
 esac
 

--- a/make.sh
+++ b/make.sh
@@ -26,8 +26,12 @@ error() {
 }
 
 generate(){
+    NAME="macOS"
+    if [[ -e version ]]; then
+        NAME="$NAME $(cat version)"
+    fi
     UUID=$( cat /proc/sys/kernel/random/uuid )
-    sed -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|QEMUHOME|$QEMU_HOME|g" -e "s|UUID|$UUID|g" -e "s|MACHINE|$MACHINE|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
+    sed -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|MACOSNAME|$NAME|g" -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|QEMUHOME|$QEMU_HOME|g" -e "s|UUID|$UUID|g" -e "s|MACHINE|$MACHINE|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
     echo "$OUT has been generated in $VMDIR"
 }
 
@@ -41,11 +45,12 @@ install(){
     cp -Zfu BaseSystem.img $BOXES_HOME
     cp -Zfu ESP.qcow2 $BOXES_HOME
     echo Coping OVMF_CODE.fd in $QEMU_HOME/firmware/
-    cp firmware/OVMF_CODE.fd $QEMU_HOME/firmware/
+    cp -Zfu firmware/OVMF_CODE.fd $QEMU_HOME/firmware/
     echo Coping OVMF_CODE.fd in $QEMU_HOME/nvram/
-    cp firmware/OVMF_VARS-1024x768.fd $QEMU_HOME/nvram/
-    echo Adding template.xml to GNOME Boxes domain
-    virsh -c qemu:///session define $OUT
+    cp -Zfu firmware/OVMF_VARS-1024x768.fd $QEMU_HOME/nvram/
+    echo Copy template.xml to $QEMU_HOME
+    cp -Zfu template.xml $QEMU_HOME/macOS-Simple-KVM.xml
+    virsh -c qemu:///session define $QEMU_HOME/macOS-Simple-KVM.xml
 }
 
 generate

--- a/make.sh
+++ b/make.sh
@@ -8,7 +8,9 @@ QEMU_HOME="$HOME/.config/libvirt/qemu"
 BOXES_HOME="$HOME/.local/share/gnome-boxes/images"
 MACHINE="$(qemu-system-x86_64 --machine help | grep q35 | cut -d" " -f1 | grep -Eoe ".*-[0-9.]+" | sort -rV | head -1)"
 OUT="template.xml"
-SIZE=60G
+DEFAULT_STORAGE=60G
+DEFAULT_MEMORY=2
+MEMORY_MULTIPLIER=1048576
 
 print_usage() {
     echo
@@ -27,6 +29,13 @@ error() {
 
 generate(){
     NAME="macOS"
+
+    read -p "How much RAM? [$DEFAULT_MEMORY]: " MEMORY
+    ## Use default 2GB memory if no memory provided
+    if [[ -n $MEMORY ]]; then MEMORY=$(($MEMORY_MULTIPLIER*$MEMORY)); else MEMORY=$(($MEMORY_MULTIPLIER*$DEFAULT_MEMORY)); fi
+
+    ## TODO do some input validation
+
     if [[ -e version ]]; then
         NAME="$NAME $(cat version)"
     fi
@@ -39,7 +48,14 @@ install(){
     echo Creating direcories $QEMU_HOME/firmware and $BOXES_HOME
     mkdir -p $BOXES_HOME
     mkdir -p $QEMU_HOME/firmware
-    echo Creating system disk $BOXES_HOME/macOS.qcow2 of size $SIZE
+
+    read -p "How much storage? [$DEFAULT_STORAGE]: " STORAGE
+    ## Use default 30G storage if no storage provided
+    if [[ -z $STORAGE ]]; then STORAGE=$DEFAULT_STORAGE; fi
+
+    ## TODO do some input validation
+
+    echo Creating system disk $BOXES_HOME/macOS.qcow2 of size $STORAGE
     qemu-img create -f qcow2 $BOXES_HOME/macOS.qcow2 $SIZE
     echo Coping BaseSystem.img and ESP.qcow2 in $BOXES_HOME
     cp -Zfu BaseSystem.img $BOXES_HOME

--- a/make.sh
+++ b/make.sh
@@ -50,9 +50,7 @@ install(){
     mkdir -p $BOXES_HOME
     mkdir -p $QEMU_HOME/firmware
 
-    read -p "How much storage? [$DEFAULT_STORAGE]: " STORAGE
-    ## Use default 60G storage if no storage provided
-    if [[ -z $STORAGE ]]; then STORAGE=$DEFAULT_STORAGE; fi
+    
 
     ## TODO do some input validation
 
@@ -60,6 +58,9 @@ install(){
     if [[ -e $BOXES_HOME/macOS.qcow2 ]]; then
         echo "macOS.qcow2 already exist, skipping"
     else
+        read -p "How much storage? [$DEFAULT_STORAGE]: " STORAGE
+        ## Use default 60G storage if no storage provided
+        if [[ -z $STORAGE ]]; then STORAGE=$DEFAULT_STORAGE; fi
         qemu-img create -f qcow2 $BOXES_HOME/macOS.qcow2 $STORAGE
     fi
     echo Coping BaseSystem.img and ESP.qcow2 in $BOXES_HOME

--- a/make.sh
+++ b/make.sh
@@ -7,7 +7,9 @@ VMDIR=$PWD
 QEMU_HOME="$HOME/.config/libvirt/qemu"
 BOXES_HOME="$HOME/.local/share/gnome-boxes/images"
 MACHINE="$(qemu-system-x86_64 --machine help | grep q35 | cut -d" " -f1 | grep -Eoe ".*-[0-9.]+" | sort -rV | head -1)"
+DATA="data"
 OUT="template.xml"
+DOMAIN_NAME=macOS-Simple-KVM
 DEFAULT_STORAGE=60G
 DEFAULT_MEMORY=2
 MEMORY_MULTIPLIER=1048576
@@ -36,12 +38,12 @@ generate(){
 
     ## TODO do some input validation
 
-    if [[ -e version ]]; then
-        NAME="$NAME $(cat version)"
+    if [[ -e $DATA/version ]]; then
+        NAME="$NAME $(cat $DATA/version)"
     fi
     UUID=$( cat /proc/sys/kernel/random/uuid )
-    sed -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|MACOSNAME|$NAME|g" -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|QEMUHOME|$QEMU_HOME|g" -e "s|UUID|$UUID|g" -e "s|MACHINE|$MACHINE|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
-    echo "$OUT has been generated in $VMDIR"
+    sed -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|MACOSNAME|$NAME|g" -e "s|BOXESHOME|$BOXES_HOME|g" -e "s|QEMUHOME|$QEMU_HOME|g" -e "s|UUID|$UUID|g" -e "s|MACHINE|$MACHINE|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $DATA/$OUT
+    echo "$OUT has been generated in $VMDIR$/$DATA"
 }
 
 install(){
@@ -64,9 +66,9 @@ install(){
     cp -Zfu firmware/OVMF_CODE.fd $QEMU_HOME/firmware/
     echo Coping OVMF_CODE.fd in $QEMU_HOME/nvram/
     cp -Zfu firmware/OVMF_VARS-1024x768.fd $QEMU_HOME/nvram/
-    echo Copy template.xml to $QEMU_HOME
-    cp -Zfu template.xml $QEMU_HOME/macOS-Simple-KVM.xml
-    virsh -c qemu:///session define $QEMU_HOME/macOS-Simple-KVM.xml
+    echo Copy $OUT to $QEMU_HOME
+    cp -Zfu $DATA/$OUT $QEMU_HOME/$DOMAIN_NAME.xml
+    virsh -c qemu:///session define $QEMU_HOME/$DOMAIN_NAME.xml
 }
 
 generate

--- a/make.sh
+++ b/make.sh
@@ -21,7 +21,8 @@ error() {
 }
 
 generate(){
-    sed -e "s|VMDIR|$VMDIR|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
+    UUID=$( cat /proc/sys/kernel/random/uuid )
+    sed -e "s|VMDIR|$VMDIR|g" -e "s|UUID|$UUID|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
     echo "$OUT has been generated in $VMDIR"
 }
 
@@ -30,7 +31,7 @@ generate
 argument="$1"
 case $argument in
     -a|--add)
-        sudo virsh define $OUT
+        virsh -c qemu:///session define $OUT
         ;;
     -h|--help)
         print_usage

--- a/make.sh
+++ b/make.sh
@@ -57,7 +57,11 @@ install(){
     ## TODO do some input validation
 
     echo Creating system disk $BOXES_HOME/macOS.qcow2 of size $STORAGE
-    qemu-img create -f qcow2 $BOXES_HOME/macOS.qcow2 $STORAGE
+    if [[ -e $BOXES_HOME/macOS.qcow2 ]]; then
+        echo "macOS.qcow2 already exist, skipping"
+    else
+        qemu-img create -f qcow2 $BOXES_HOME/macOS.qcow2 $STORAGE
+    fi
     echo Coping BaseSystem.img and ESP.qcow2 in $BOXES_HOME
     cp -Zfu BaseSystem.img $BOXES_HOME
     cp -Zfu ESP.qcow2 $BOXES_HOME

--- a/tools/FetchMacOS/fetch-macos.py
+++ b/tools/FetchMacOS/fetch-macos.py
@@ -66,6 +66,12 @@ class Filesystem:
 class SoftwareService:
     # macOS 10.15 is available in 4 different catalogs from SoftwareScan
     catalogs = {
+                "10.16": {
+                    "CustomerSeed":"https://swscan.apple.com/content/catalogs/others/index-10.16customerseed-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog",
+                    "DeveloperSeed":"https://swscan.apple.com/content/catalogs/others/index-10.16seed-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog",
+                    "PublicSeed":"https://swscan.apple.com/content/catalogs/others/index-10.16beta-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog",
+                    "PublicRelease":"https://swscan.apple.com/content/catalogs/others/index-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog"
+                        },
                 "10.15": {
                     "CustomerSeed":"https://swscan.apple.com/content/catalogs/others/index-10.15customerseed-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog",
                     "DeveloperSeed":"https://swscan.apple.com/content/catalogs/others/index-10.15seed-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog",
@@ -133,7 +139,8 @@ class MacOSProduct:
 @click.option('-v', '--catalog-version', default="10.15", help="Version of catalog.")
 @click.option('-c', '--catalog-id', default="PublicRelease", help="Name of catalog.")
 @click.option('-p', '--product-id', default="", help="Product ID (as seen in SoftwareUpdate).")
-def fetchmacos(output_dir="BaseSystem/", catalog_version="10.15", catalog_id="PublicRelease", product_id=""):
+@click.option('-k', '--keyword', default=None, help="Keyword filter for packages.")
+def fetchmacos(output_dir="BaseSystem/", catalog_version="10.15", catalog_id="PublicRelease", product_id="", keyword=None):
     # Get the remote catalog data
     remote = SoftwareService(catalog_version, catalog_id)
     catalog = remote.getcatalog()
@@ -152,7 +159,7 @@ def fetchmacos(output_dir="BaseSystem/", catalog_version="10.15", catalog_id="Pu
     logging.info("Selected macOS Product: {}".format(product_id))
 
     # Download package to disk
-    product.fetchpackages(output_dir, keyword="BaseSystem")
+    product.fetchpackages(output_dir, keyword=keyword)
 
 if __name__ == "__main__":
     fetchmacos()

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -2,13 +2,13 @@
   <name>macOS-Simple-KVM</name>
   <uuid>UUID</uuid>
   <title>macOS</title>
-  <memory unit="KiB">2097152</memory>
-  <currentMemory unit="KiB">2097152</currentMemory>
+  <memory unit="KiB">4194304</memory>
+  <currentMemory unit="KiB">4194304</currentMemory>
   <vcpu placement="static">4</vcpu>
   <os>
     <type arch="x86_64" machine="MACHINE">hvm</type>
-    <loader readonly="yes" type="pflash">VMDIR/firmware/OVMF_CODE.fd</loader>
-    <nvram>VMDIR/firmware/OVMF_VARS-1024x768.fd</nvram>
+    <loader readonly="yes" type="pflash">QEMUHOME/firmware/OVMF_CODE.fd</loader>
+    <nvram>QEMUHOME/nvram/OVMF_VARS-1024x768.fd</nvram>
     <boot dev="hd" />
   </os>
   <features>
@@ -35,15 +35,21 @@
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2" />
-      <source file="VMDIR/ESP.qcow2" />
+      <source file="BOXESHOME/ESP.qcow2" />
       <target dev="sda" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="0" />
     </disk>
     <disk type="file" device="disk">
       <driver name="qemu" type="raw" />
-      <source file="VMDIR/BaseSystem.img" />
+      <source file="BOXESHOME/BaseSystem.img" />
       <target dev="sdb" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="1" />
+    </disk>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="raw" />
+      <source file="BOXESHOME/macOS.img" />
+      <target dev="sdb" bus="sata" />
+      <address type="drive" controller="0" bus="0" target="0" unit="2" />
     </disk>
     <controller type="usb" index="0" model="ich9-ehci1">
       <address type="pci" domain="0x0000" bus="0x00" slot="0x1d" function="0x7" />

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -47,8 +47,8 @@
     </disk>
     <disk type="file" device="disk">
       <driver name="qemu" type="raw" />
-      <source file="BOXESHOME/macOS.img" />
-      <target dev="sdb" bus="sata" />
+      <source file="BOXESHOME/macOS.qcow2" />
+      <target dev="sdc" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="2" />
     </disk>
     <controller type="usb" index="0" model="ich9-ehci1">

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -1,7 +1,7 @@
 <domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>macOS-Simple-KVM</name>
   <uuid>UUID</uuid>
-  <title>macOS</title>
+  <title>MACOSNAME</title>
   <memory unit="KiB">4194304</memory>
   <currentMemory unit="KiB">4194304</currentMemory>
   <vcpu placement="static">4</vcpu>
@@ -34,7 +34,7 @@
   <devices>
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type="file" device="disk">
-      <driver name="qemu" type="qcow2" />
+      <driver name="qemu" type="qcow2" cache="writeback" io="threads" />
       <source file="BOXESHOME/ESP.qcow2" />
       <target dev="sda" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="0" />
@@ -46,7 +46,7 @@
       <address type="drive" controller="0" bus="0" target="0" unit="1" />
     </disk>
     <disk type="file" device="disk">
-      <driver name="qemu" type="raw" />
+      <driver name="qemu" type="qcow2" cache="writeback" io="threads" />
       <source file="BOXESHOME/macOS.qcow2" />
       <target dev="sdc" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="2" />
@@ -83,21 +83,22 @@
       <target type="serial" port="0" />
     </console>
     <input type="tablet" bus="usb">
-      <address type="usb" bus="0" port="1"/>
-    </input>   
+      <address type="usb" bus="0" port="1" />
+    </input>
     <input type="keyboard" bus="usb">
       <address type="usb" bus="0" port="2" />
     </input>
-    <graphics type="spice" autoport="yes">
-      <listen type="address" />
+    <graphics type="spice">
+      <listen type="none" />
       <image compression="off" />
+      <gl enable="no" />
     </graphics>
     <sound model="ich9">
       <address type="pci" domain="0x0000" bus="0x00" slot="0x1b" function="0x0" />
     </sound>
     <video>
-      <model type="vga" vram="131072" heads="1" primary="yes"/>
-      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0"/>
+      <model type="vga" vram="131072" heads="1" primary="yes" />
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0" />
     </video>
     <redirdev bus="usb" type="spicevmc">
       <address type="usb" bus="0" port="3" />
@@ -107,10 +108,10 @@
     </redirdev>
     <memballoon model="none" />
   </devices>
-  <seclabel type="dynamic" model="selinux" relabel="yes"/>
+  <seclabel type="dynamic" model="selinux" relabel="yes" />
   <qemu:commandline>
     <qemu:arg value="-cpu" />
-    <qemu:arg value="Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check" />
+    <qemu:arg value="Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,vmx=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check" />
     <qemu:arg value="-device" />
     <qemu:arg value="isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc" />
     <qemu:arg value="-smbios" />

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -40,14 +40,14 @@
       <address type="drive" controller="0" bus="0" target="0" unit="0" />
     </disk>
     <disk type="file" device="disk">
-      <driver name="qemu" type="raw" />
-      <source file="BOXESHOME/BaseSystem.img" />
+      <driver name="qemu" type="qcow2" cache="writeback" io="threads" />
+      <source file="BOXESHOME/macOS.qcow2" />
       <target dev="sdb" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="1" />
     </disk>
     <disk type="file" device="disk">
-      <driver name="qemu" type="qcow2" cache="writeback" io="threads" />
-      <source file="BOXESHOME/macOS.qcow2" />
+      <driver name="qemu" type="raw" />
+      <source file="BOXESHOME/BaseSystem.img" />
       <target dev="sdc" bus="sata" />
       <address type="drive" controller="0" bus="0" target="0" unit="2" />
     </disk>

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -1,113 +1,113 @@
-<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>macOS-Simple-KVM</name>
-  <uuid>d06d502a-904a-4b34-847d-debf1a3d76c7</uuid>
-  <memory unit='KiB'>2097152</memory>
-  <currentMemory unit='KiB'>2097152</currentMemory>
-  <vcpu placement='static'>4</vcpu>
+  <uuid>UUID</uuid>
+  <title>macOS</title>
+  <memory unit="KiB">2097152</memory>
+  <currentMemory unit="KiB">2097152</currentMemory>
+  <vcpu placement="static">4</vcpu>
   <os>
-    <type arch='x86_64' machine='MACHINE'>hvm</type>
-    <loader readonly='yes' type='pflash'>VMDIR/firmware/OVMF_CODE.fd</loader>
+    <type arch="x86_64" machine="MACHINE">hvm</type>
+    <loader readonly="yes" type="pflash">VMDIR/firmware/OVMF_CODE.fd</loader>
     <nvram>VMDIR/firmware/OVMF_VARS-1024x768.fd</nvram>
-    <boot dev='hd'/>
+    <boot dev="hd" />
   </os>
   <features>
-    <acpi/>
-    <apic/>
-    <vmport state='off'/>
+    <acpi />
+    <apic />
+    <vmport state="off" />
   </features>
   <cpu>
-    <topology sockets='1' cores='4' threads='1'/>
+    <topology sockets="1" cores="4" threads="1" />
   </cpu>
-  <clock offset='utc'>
-    <timer name='rtc' tickpolicy='catchup'/>
-    <timer name='pit' tickpolicy='delay'/>
-    <timer name='hpet' present='no'/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup" />
+    <timer name="pit" tickpolicy="delay" />
+    <timer name="hpet" present="no" />
   </clock>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>
   <on_crash>destroy</on_crash>
   <pm>
-    <suspend-to-mem enabled='no'/>
-    <suspend-to-disk enabled='no'/>
+    <suspend-to-mem enabled="no" />
+    <suspend-to-disk enabled="no" />
   </pm>
   <devices>
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
-    <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
-      <source file='VMDIR/ESP.qcow2'/>
-      <target dev='sda' bus='sata'/>
-      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" />
+      <source file="VMDIR/ESP.qcow2" />
+      <target dev="sda" bus="sata" />
+      <address type="drive" controller="0" bus="0" target="0" unit="0" />
     </disk>
-    <disk type='file' device='disk'>
-      <driver name='qemu' type='raw'/>
-      <source file='VMDIR/BaseSystem.img'/>
-      <target dev='sdb' bus='sata'/>
-      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="raw" />
+      <source file="VMDIR/BaseSystem.img" />
+      <target dev="sdb" bus="sata" />
+      <address type="drive" controller="0" bus="0" target="0" unit="1" />
     </disk>
-    <controller type='usb' index='0' model='ich9-ehci1'>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x7'/>
+    <controller type="usb" index="0" model="ich9-ehci1">
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x1d" function="0x7" />
     </controller>
-    <controller type='usb' index='0' model='ich9-uhci1'>
-      <master startport='0'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x0' multifunction='on'/>
+    <controller type="usb" index="0" model="ich9-uhci1">
+      <master startport="0" />
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x1d" function="0x0" multifunction="on" />
     </controller>
-    <controller type='usb' index='0' model='ich9-uhci2'>
-      <master startport='2'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x1'/>
+    <controller type="usb" index="0" model="ich9-uhci2">
+      <master startport="2" />
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x1d" function="0x1" />
     </controller>
-    <controller type='usb' index='0' model='ich9-uhci3'>
-      <master startport='4'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x2'/>
+    <controller type="usb" index="0" model="ich9-uhci3">
+      <master startport="4" />
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x1d" function="0x2" />
     </controller>
-    <controller type='sata' index='0'>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    <controller type="sata" index="0">
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x1f" function="0x2" />
     </controller>
-    <interface type='network'>
-      <mac address='52:54:00:92:d4:7b'/>
-      <source network='default'/>
-      <model type='e1000-82545em'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    <interface type="user">
+      <mac address="52:54:00:92:d4:7b" />
+      <model type="e1000-82545em" />
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x02" function="0x0" />
     </interface>
-    <serial type='pty'>
-      <target type='isa-serial' port='0'>
-        <model name='isa-serial'/>
+    <serial type="pty">
+      <target type="isa-serial" port="0">
+        <model name="isa-serial" />
       </target>
     </serial>
-    <console type='pty'>
-      <target type='serial' port='0'/>
+    <console type="pty">
+      <target type="serial" port="0" />
     </console>
-    <input type='mouse' bus='usb'>
-      <address type='usb' bus='0' port='1'/>
+    <input type="tablet" bus="usb">
+      <address type="usb" bus="0" port="1"/>
+    </input>   
+    <input type="keyboard" bus="usb">
+      <address type="usb" bus="0" port="2" />
     </input>
-    <input type='keyboard' bus='usb'>
-      <address type='usb' bus='0' port='2'/>
-    </input>
-    <graphics type='spice' autoport='yes'>
-      <listen type='address'/>
-      <image compression='off'/>
+    <graphics type="spice" autoport="yes">
+      <listen type="address" />
+      <image compression="off" />
     </graphics>
-    <sound model='ich9'>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x1b' function='0x0'/>
+    <sound model="ich9">
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x1b" function="0x0" />
     </sound>
     <video>
-      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+      <model type="vga" vram="131072" heads="1" primary="yes"/>
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0"/>
     </video>
-    <redirdev bus='usb' type='spicevmc'>
-      <address type='usb' bus='0' port='3'/>
+    <redirdev bus="usb" type="spicevmc">
+      <address type="usb" bus="0" port="3" />
     </redirdev>
-    <redirdev bus='usb' type='spicevmc'>
-      <address type='usb' bus='0' port='4'/>
+    <redirdev bus="usb" type="spicevmc">
+      <address type="usb" bus="0" port="4" />
     </redirdev>
-    <memballoon model='none'/>
+    <memballoon model="none" />
   </devices>
+  <seclabel type="dynamic" model="selinux" relabel="yes"/>
   <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
-    <qemu:arg value='-device'/>
-    <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
-    <qemu:arg value='-smbios'/>
-    <qemu:arg value='type=2'/>
+    <qemu:arg value="-cpu" />
+    <qemu:arg value="Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check" />
+    <qemu:arg value="-device" />
+    <qemu:arg value="isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc" />
+    <qemu:arg value="-smbios" />
+    <qemu:arg value="type=2" />
   </qemu:commandline>
 </domain>
-


### PR DESCRIPTION
Updated scripts to make easier to generate domain template and add them to usermode qemu, adding support for GNOME Boxes, fixing also input using USB Tablet.
Uses `vga` video to allow resolution selection from macOS settings.
fixes #149