### PR TITLE
Make Nix/NixOS friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ sudo xbps-install -Su qemu python3 python3-pip   # for Void Linux.
 sudo zypper in qemu-tools qemu-kvm qemu-x86 qemu-audio-pa python3-pip  # for openSUSE Tumbleweed
 sudo dnf install qemu qemu-img python3 python3-pip # for Fedora
 sudo emerge -a qemu python:3.4 pip # for Gentoo
+nix-shell # for Nix users
 ```
 
 ## Step 1

--- a/basic.sh
+++ b/basic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OSK="ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
 VMDIR=$PWD

--- a/headless.sh
+++ b/headless.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OSK="ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
 VMDIR=$PWD

--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # jumpstart.sh: Fetches BaseSystem and converts it to a viable format.
 # by Foxlet <foxlet@furcode.co>

--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -38,4 +38,10 @@ esac
 
 "$TOOLS/FetchMacOS/fetch.sh" -v $version || exit 1
 
-"$TOOLS/dmg2img" "$TOOLS/FetchMacOS/BaseSystem/BaseSystem.dmg" "$PWD/BaseSystem.img"
+if [ -x "$(command -v dmg2img)" ]; then
+    dmg2img="dmg2img"
+else
+    dmg2img="$TOOLS/dmg2img"
+fi
+
+"$dmg2img" "$TOOLS/FetchMacOS/BaseSystem/BaseSystem.dmg" "$PWD/BaseSystem.img"

--- a/jumpstart.sh
+++ b/jumpstart.sh
@@ -26,14 +26,16 @@ case $argument in
         print_usage
         ;;
     -s|--high-sierra)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.13 || exit 1;
+        version=10.13
         ;;
     -m|--mojave)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.14 || exit 1;
+        version=10.14
         ;;
     -c|--catalina|*)
-        "$TOOLS/FetchMacOS/fetch.sh" -v 10.15 || exit 1;
+        version=10.15
         ;;
 esac
+
+"$TOOLS/FetchMacOS/fetch.sh" -v $version || exit 1
 
 "$TOOLS/dmg2img" "$TOOLS/FetchMacOS/BaseSystem/BaseSystem.dmg" "$PWD/BaseSystem.img"

--- a/make.sh
+++ b/make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # make.sh: Generate customized libvirt XML.
 # by Foxlet <foxlet@furcode.co>

--- a/make.sh
+++ b/make.sh
@@ -7,6 +7,14 @@ VMDIR=$PWD
 MACHINE="$(qemu-system-x86_64 --machine help | grep q35 | cut -d" " -f1 | grep -Eoe ".*-[0-9.]+" | sort -rV | head -1)"
 OUT="template.xml"
 
+NIX_EMULATOR="/run/libvirt/nix-emulators/qemu-system-x86_64"
+
+if [ -e $NIX_EMULATOR ]; then
+   EMULATOR=$NIX_EMULATOR
+else
+   EMULATOR="/usr/bin/qemu-system-x86_64"
+fi
+
 print_usage() {
     echo
     echo "Usage: $0"
@@ -21,7 +29,7 @@ error() {
 }
 
 generate(){
-    sed -e "s|VMDIR|$VMDIR|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
+    sed -e "s|VMDIR|$VMDIR|g" -e "s|MACHINE|$MACHINE|g" -e "s|EMULATOR|$EMULATOR|g" tools/template.xml.in > $OUT
     echo "$OUT has been generated in $VMDIR"
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    qemu_kvm
+    dmg2img
+  ];
+}

--- a/tools/FetchMacOS/fetch.sh
+++ b/tools/FetchMacOS/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # fetch.sh: Run fetch-macos.py with safety checks
 # by Foxlet <foxlet@furcode.co>

--- a/tools/FetchMacOS/fetch.sh
+++ b/tools/FetchMacOS/fetch.sh
@@ -7,6 +7,12 @@ set +x;
 SCRIPTDIR="$(dirname "$0")";
 cd "$SCRIPTDIR"
 
+if [ -x "$(command -v nix-shell)" ]; then
+    echo "Nix detected, using nix-shell for dependencies..."
+    nix-shell --pure --run "python fetch-macos.py $*"
+    exit
+fi
+
 initpip() {
     if [ -x "$(command -v easy_install)" ]; then
         sudo easy_install pip

--- a/tools/FetchMacOS/shell.nix
+++ b/tools/FetchMacOS/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  propagatedBuildInputs = with pkgs.python3Packages; [
+    python
+    requests
+    click
+  ];
+}

--- a/tools/debug.sh
+++ b/tools/debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # debug.sh: Checks common virtualization programs and modules.
 # by Foxlet <foxlet@furcode.co>

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -31,7 +31,7 @@
     <suspend-to-disk enabled='no'/>
   </pm>
   <devices>
-    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <emulator>EMULATOR</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='VMDIR/ESP.qcow2'/>

--- a/virtio.sh
+++ b/virtio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OSK="ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
 VMDIR=$PWD


### PR DESCRIPTION
The project does not work on NixOS OOTB because of FHS assumptions. Nix dependencies also aren't mentioned in the README.

This PR removes the dependency on /bin/bash and /lib64/ and provides dependencies for Nix users (semi-)automatically.

Supersedes #223.

Related: #238 #228