### PR TITLE
Prepended $VMDIR to all image paths for consistency

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OSK="ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
-VMDIR=$PWD
+VMDIR="$PWD"
 OVMF=$VMDIR/firmware
 #export QEMU_AUDIO_DRV=pa
 #QEMU_AUDIO_DRV=pa
@@ -22,7 +22,9 @@ qemu-system-x86_64 \
     -netdev user,id=net0 \
     -device e1000-82545em,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
     -device ich9-ahci,id=sata \
-    -drive id=ESP,if=none,format=qcow2,file=ESP.qcow2 \
+    -drive id=ESP,if=none,format=qcow2,file="$VMDIR/ESP.qcow2" \
     -device ide-hd,bus=sata.2,drive=ESP \
-    -drive id=InstallMedia,format=raw,if=none,file=BaseSystem.img \
+    -drive id=InstallMedia,format=raw,if=none,file="$VMDIR/BaseSystem.img" \
     -device ide-hd,bus=sata.3,drive=InstallMedia \
+    -drive id=SystemDisk,if=none,file="$VMDIR/MyDisk.qcow2" \
+    -device ide-hd,bus=sata.4,drive=SystemDisk


### PR DESCRIPTION
There is a `$VMDIR` variable that defaults to "$PWD" and defines the base directory for the `$OVMF`. The BaseSystem and ESP partitons have no prefix however, so 2 of the 4 paths are getting `$PWD` included explicitly and the other two assume it implicitly. This will break if $VMDIR is defined as a different directory then the project root, or if the script is run from outside the project root.

I just prepended `$VMDIR` to those paths as well be consistent if `$VMDIR` is redefined.

_Also:
It might be safer to use `$(dirname $0)` instead of `$PWD` as a default, since what we probably want is "the same directory as where this script is" and not necessarily "the directory the user ran this from." But I didn't change that in this pull request._