### PR TITLE
[TOOLS] More options for defining VM templates

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -5,13 +5,21 @@
 
 VMDIR=$PWD
 MACHINE="$(qemu-system-x86_64 --machine help | grep q35 | cut -d" " -f1 | grep -Eoe ".*-[0-9.]+" | sort -rV | head -1)"
+VMNAME="macOS-Simple-KVM"
+VMUUID="d06d502a-904a-4b34-847d-debf1a3d76c7"
+VMCPUS=4
+VMMEM=2097152
 OUT="template.xml"
 
 print_usage() {
     echo
     echo "Usage: $0"
     echo
-    echo " -a, --add   Add XML to virsh (uses sudo)."
+    echo " -a, --add        Add XML to virsh (uses sudo)."
+    echo " -n, --name <str> Name of the VM (default 'macOS-Simple-KVM')"
+    echo " -u, --uuid       Generates a new UUID for the VM"
+    echo " -c, --cpu  <int> VM CPU count (default 4)"
+    echo " -m, --mem  <int> VM memory in KiB (default 2097152)"
     echo
 }
 
@@ -21,18 +29,45 @@ error() {
 }
 
 generate(){
-    sed -e "s|VMDIR|$VMDIR|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
+    sed -e "s|macOS-Simple-KVM|$VMNAME|g" -e "s|d06d502a-904a-4b34-847d-debf1a3d76c7|$VMUUID|g" -e "s|VMCPUS|$VMCPUS|g" -e "s|VMMEM|$VMMEM|g" -e "s|VMDIR|$VMDIR|g" -e "s|MACHINE|$MACHINE|g" tools/template.xml.in > $OUT
     echo "$OUT has been generated in $VMDIR"
 }
 
+while [[ $# -gt 0 ]]; do
+    argument="$1"
+    case $argument in
+        -a|--add)
+            ADD=1
+            shift
+            ;;
+        -n|--name)
+            VMNAME="$2"
+            shift
+            shift
+            ;;
+        -u|--uuid)
+            VMUUID="$(uuidgen)"
+            shift
+            ;;
+        -c|--cpu)
+            VMCPUS=$2
+            shift
+            shift
+            ;;
+        -m|--mem)
+            VMMEM=$2
+            shift
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            shift
+            ;;
+    esac
+done
+
 generate
 
-argument="$1"
-case $argument in
-    -a|--add)
-        sudo virsh define $OUT
-        ;;
-    -h|--help)
-        print_usage
-        ;;
-esac
+if [[ $ADD -eq 1 ]]; then
+    sudo virsh define $OUT
+fi

--- a/tools/template.xml.in
+++ b/tools/template.xml.in
@@ -1,9 +1,9 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>macOS-Simple-KVM</name>
   <uuid>d06d502a-904a-4b34-847d-debf1a3d76c7</uuid>
-  <memory unit='KiB'>2097152</memory>
-  <currentMemory unit='KiB'>2097152</currentMemory>
-  <vcpu placement='static'>4</vcpu>
+  <memory unit='KiB'>VMMEM</memory>
+  <currentMemory unit='KiB'>VMMEM</currentMemory>
+  <vcpu placement='static'>VMCPUS</vcpu>
   <os>
     <type arch='x86_64' machine='MACHINE'>hvm</type>
     <loader readonly='yes' type='pflash'>VMDIR/firmware/OVMF_CODE.fd</loader>
@@ -16,7 +16,7 @@
     <vmport state='off'/>
   </features>
   <cpu>
-    <topology sockets='1' cores='4' threads='1'/>
+    <topology sockets='1' cores='VMCPUS' threads='1'/>
   </cpu>
   <clock offset='utc'>
     <timer name='rtc' tickpolicy='catchup'/>


### PR DESCRIPTION
The make.sh script now supports more command-line options when generating the VM template, including defining a different name, a freshly generated UUID (via uuidgen), and CPU/memory count.