### PR TITLE
fetch-macos.py: Fix shebang line.

### DIFF
--- a/tools/FetchMacOS/fetch-macos.py
+++ b/tools/FetchMacOS/fetch-macos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """fetch-macos.py: Fetches macOS products from Apple's SoftwareUpdate service."""
 


### PR DESCRIPTION
The proper form for a generic Python shebang line is:

    #!/usr/bin/env python

This locates 'python' in the current PATH.

TESTED:
Now runs the expected Python.