### PR TITLE
[CONF] Add popcount instruction

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -11,7 +11,7 @@ qemu-system-x86_64 \
     -m 2G \
     -machine q35,accel=kvm \
     -smp 4,cores=2 \
-    -cpu Penryn,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc \
+    -cpu Penryn,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+popcnt,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc \
     -device isa-applesmc,osk="$OSK" \
     -smbios type=2 \
     -drive if=pflash,format=raw,readonly,file="$OVMF/OVMF_CODE.fd" \


### PR DESCRIPTION
Although Penryn processor did not have popcount instruction, adding it here works.

This is e. g. required for OpenCV, since even when compiling from source, the detection seems to fail (in OpenCV 4.5.2_4 built with homebrew) and popcount is always recognized also in case it is not added in the CPU configuration. This commit fixes this issue.