### PR TITLE
Create a variable containing all startup arguments to allow comments

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -26,6 +26,9 @@ args=(
     -device ide-hd,bus=sata.2,drive=ESP \
     -drive id=InstallMedia,format=raw,if=none,file=BaseSystem.img \
     -device ide-hd,bus=sata.3,drive=InstallMedia \
+    ### add device/file that you have installed macos on
+    #-drive id=SystemDisk,if=none,file=MyDisk.qcow2 \
+    #-device ide-hd,bus=sata.4,drive=SystemDisk \
 )
 
 qemu-system-x86_64 "${args[@]}"

--- a/basic.sh
+++ b/basic.sh
@@ -6,7 +6,7 @@ OVMF=$VMDIR/firmware
 #export QEMU_AUDIO_DRV=pa
 #QEMU_AUDIO_DRV=pa
 
-qemu-system-x86_64 \
+args=(
     -enable-kvm \
     -m 2G \
     -machine q35,accel=kvm \
@@ -26,3 +26,6 @@ qemu-system-x86_64 \
     -device ide-hd,bus=sata.2,drive=ESP \
     -drive id=InstallMedia,format=raw,if=none,file=BaseSystem.img \
     -device ide-hd,bus=sata.3,drive=InstallMedia \
+)
+
+qemu-system-x86_64 "${args[@]}"

--- a/headless.sh
+++ b/headless.sh
@@ -28,7 +28,7 @@ MOREARGS=()
     MOREARGS+=(-nographic -vnc :0 -k en-us)
 }
 
-qemu-system-x86_64 \
+args=(
     -enable-kvm \
     -m $MEM \
     -machine q35,accel=kvm \
@@ -50,3 +50,6 @@ qemu-system-x86_64 \
     -drive id=SystemDisk,if=none,file="${SYSTEM_DISK}" \
     -device ide-hd,bus=sata.4,drive=SystemDisk \
     "${MOREARGS[@]}"
+)
+
+qemu-system-x86_64 "${args[@]}"

--- a/virtio.sh
+++ b/virtio.sh
@@ -6,7 +6,7 @@ OVMF=$VMDIR/firmware
 #export QEMU_AUDIO_DRV=pa
 #QEMU_AUDIO_DRV=pa
 
-qemu-system-x86_64 \
+args=(
     -nodefaults \
     -enable-kvm \
     -m 2G \
@@ -24,3 +24,6 @@ qemu-system-x86_64 \
     -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:09:49:17 \
     -drive id=ESP,if=virtio,format=qcow2,file=ESP.qcow2 \
     -drive id=MyDisk,if=virtio,format=qcow2,file=MyDisk.qcow2 \
+)
+
+qemu-system-x86_64 "${args[@]}"


### PR DESCRIPTION
This pr creates an args variable that contains all startup arguments that will be passed to qemu-system-x86_64.

This allows user to create comments on additional arguments that they may pass, and comment them out accordingly to make it more organizable.