### PR TITLE
Changing deprecated "readonly" by "readonly=on"

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -14,7 +14,7 @@ qemu-system-x86_64 \
     -cpu Penryn,vendor=GenuineIntel,kvm=on,+sse3,+sse4.2,+aes,+xsave,+avx,+xsaveopt,+xsavec,+xgetbv1,+avx2,+bmi2,+smep,+bmi1,+fma,+movbe,+invtsc \
     -device isa-applesmc,osk="$OSK" \
     -smbios type=2 \
-    -drive if=pflash,format=raw,readonly,file="$OVMF/OVMF_CODE.fd" \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF/OVMF_CODE.fd" \
     -drive if=pflash,format=raw,file="$OVMF/OVMF_VARS-1024x768.fd" \
     -vga qxl \
     -device ich9-intel-hda -device hda-output \


### PR DESCRIPTION
All is in the title, it may cause bugs or crashes on startup (idk why but i fixed it and now my VM is perfect)